### PR TITLE
Refresh portal copy to remove Fallout references

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,35 +2,311 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8">
-  <title>SHOUN GAMES | ポータル</title>
+  <title>SHOUN PORTAL | ブログ &amp; ゲーム</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- ✅ AdSense サイト関連コード（所有権確認 & 配信に必須） -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8062373002822047"
           crossorigin="anonymous"></script>
 
-  <meta name="description" content="SHOUN LLCのゲームポータル。ブラウザで遊べるテトリスなどの作品を公開しています。">
-  <link rel="canonical" href="https://shoun-llc.jp/">
+  <meta name="description" content="SHOUN LLCの公式ポータルサイト。ブログとブラウザゲームの最新情報をサイバーパンクな世界観でお届けします。">
+  <link rel="canonical" href="https://www.shoun-llc.jp/">
   <style>
-    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0}
-    header{padding:32px 20px;text-align:center;border-bottom:1px solid #eee}
-    main{max-width:960px;margin:0 auto;padding:24px}
-    .card{border:1px solid #eee;border-radius:12px;padding:20px;margin:16px 0}
-    .btn{display:inline-block;padding:12px 20px;border-radius:999px;border:1px solid #333;text-decoration:none}
-    .btn:hover{background:#f5f5f5}
-    footer{color:#666;font-size:12px;text-align:center;padding:24px 0;border-top:1px solid #eee;margin-top:40px}
+    :root{color-scheme:dark;--bg:#040611;--panel:#0d1024;--glow:#00ffe0;--text:#e1f9ff;--muted:#8aa4b4}
+    *{box-sizing:border-box}
+    body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;margin:0;color:var(--text);background:radial-gradient(circle at 40% -10%,rgba(47,255,193,.35) 0%,rgba(9,18,38,.85) 55%,var(--bg) 75%),linear-gradient(145deg,rgba(116,28,146,.3),rgba(0,255,224,.05));background-color:var(--bg);background-attachment:fixed}
+    body::before{content:"";position:fixed;inset:0;background:rgba(4,6,17,.75);backdrop-filter:blur(4px);z-index:-1}
+    header{padding:48px 20px 32px;border-bottom:1px solid rgba(0,255,224,.25);background:linear-gradient(120deg,rgba(0,255,224,.1),rgba(33,10,60,.3));box-shadow:0 0 32px rgba(0,255,224,.15)}
+    .hero-inner{display:flex;flex-direction:column-reverse;gap:32px;max-width:1080px;margin:0 auto;align-items:center}
+    .hero-text{text-align:center;max-width:520px}
+    h1{font-size:2.8rem;margin:0 0 16px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;text-shadow:0 0 12px rgba(0,255,224,.7)}
+    .tagline{margin:0 0 24px;color:var(--muted);line-height:1.7}
+    .hero-links{display:flex;justify-content:center;gap:16px;flex-wrap:wrap}
+    .hero-art{margin:0;max-width:560px;border-radius:24px;overflow:hidden;box-shadow:0 0 24px rgba(0,255,224,.35);border:1px solid rgba(0,255,224,.35);background:rgba(10,14,36,.9)}
+    .hero-art img,.hero-art svg{display:block;width:100%;height:auto}
+    main{max-width:1080px;margin:0 auto;padding:48px 20px;display:grid;gap:32px}
+    .card{background:rgba(10,12,32,.85);border:1px solid rgba(0,255,224,.2);border-radius:18px;padding:28px;box-shadow:0 18px 32px -24px rgba(0,0,0,.9);backdrop-filter:blur(6px);transition:transform .3s ease,box-shadow .3s ease}
+    .card:hover{transform:translateY(-4px);box-shadow:0 24px 40px -20px rgba(0,255,224,.25)}
+    .card h2,.card h3{margin-top:0;font-size:1.6rem;text-shadow:0 0 12px rgba(0,255,224,.35)}
+    .card p,.card li{color:var(--muted);line-height:1.8}
+    .card--feature{display:grid;gap:24px;align-items:center}
+    .card--feature .card-text{display:grid;gap:16px}
+    .card-visual{margin:0;border-radius:16px;overflow:hidden;background:linear-gradient(135deg,rgba(14,20,48,.9),rgba(0,255,224,.08));border:1px solid rgba(0,255,224,.25);box-shadow:0 16px 38px -28px rgba(0,255,224,.75)}
+    .card-visual svg{display:block;width:100%;height:auto}
+    .card--feature.card--alt .card-visual{order:2}
+    .card--feature.card--alt .card-text{order:1}
+    .media-grid{display:grid;gap:20px;margin-top:24px}
+    .media-grid figure{margin:0;padding:20px;border-radius:16px;background:rgba(10,14,36,.92);border:1px solid rgba(0,255,224,.18);box-shadow:0 16px 30px -24px rgba(0,0,0,.9);backdrop-filter:blur(6px)}
+    .media-grid svg{display:block;width:100%;height:auto;margin-bottom:16px}
+    .media-grid figcaption{color:var(--muted);font-size:.95rem;line-height:1.7}
+    .btn{display:inline-block;padding:14px 24px;border-radius:999px;border:1px solid rgba(0,255,224,.8);text-decoration:none;color:var(--text);text-transform:uppercase;font-weight:600;letter-spacing:.08em;box-shadow:0 0 16px rgba(0,255,224,.35);transition:background .3s ease,box-shadow .3s ease,transform .2s ease}
+    .btn:hover{background:rgba(0,255,224,.12);box-shadow:0 0 22px rgba(0,255,224,.6);transform:translateY(-2px)}
+    footer{color:var(--muted);font-size:12px;text-align:center;padding:32px 0;border-top:1px solid rgba(0,255,224,.15);margin-top:48px;letter-spacing:.04em;text-transform:uppercase}
+    @media(min-width:720px){.media-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+    @media(min-width:900px){.hero-inner{flex-direction:row;justify-content:space-between;text-align:left}.hero-text{text-align:left}.hero-links{justify-content:flex-start}.hero-art{max-width:520px}.card--feature{grid-template-columns:minmax(0,320px) minmax(0,1fr)}.card--feature.card--alt{grid-template-columns:minmax(0,1fr) minmax(0,320px)}}
+    @media(max-width:600px){h1{font-size:2.2rem}.card{padding:22px}.btn{width:100%;text-align:center}}
   </style>
 </head>
 <body>
 <header>
-  <h1>SHOUN GAMES</h1>
-  <p>ブラウザで遊べる作品のまとめポータル</p>
+  <div class="hero-inner">
+    <div class="hero-text">
+      <h1>SHOUN PORTAL</h1>
+      <p class="tagline">ショウウン合同会社が運営する公式ポータル。ブログとオリジナルゲームの世界を、サイバーパンクな都市の光とともにお楽しみください。</p>
+      <div class="hero-links">
+        <a class="btn" href="https://blog.shoun-llc.jp/">ブログを見る</a>
+        <a class="btn" href="https://tetris.shoun-llc.jp/?from=portal">ゲームで遊ぶ</a>
+      </div>
+    </div>
+    <figure class="hero-art">
+      <svg viewBox="0 0 640 400" role="img" aria-labelledby="vault-title vault-desc">
+        <title id="vault-title">ネオンシェルターのゲート</title>
+        <desc id="vault-desc">サイバーパンクな地下都市へ通じる、ネオンに輝く巨大なギア型ドアのイラスト。</desc>
+        <defs>
+          <linearGradient id="vault-bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#070b1a" />
+            <stop offset="100%" stop-color="#1a0f2e" />
+          </linearGradient>
+          <radialGradient id="vault-glow" cx="50%" cy="42%" r="62%">
+            <stop offset="0%" stop-color="#2fffc1" stop-opacity="0.92" />
+            <stop offset="45%" stop-color="#123459" stop-opacity="0.65" />
+            <stop offset="100%" stop-color="#050912" stop-opacity="1" />
+          </radialGradient>
+        </defs>
+        <rect width="640" height="400" fill="url(#vault-bg)" />
+        <circle cx="320" cy="200" r="200" fill="url(#vault-glow)" opacity="0.6" />
+        <g transform="translate(320 200)">
+          <circle r="185" fill="none" stroke="#2fffc1" stroke-opacity="0.28" stroke-width="4" stroke-dasharray="6 18" />
+          <g fill="#2fffc122">
+            <rect x="-18" y="-212" width="36" height="76" rx="14" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(180)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(150)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(120)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(90)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(60)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(30)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(-30)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(-60)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(-90)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(-120)" />
+            <rect x="-18" y="136" width="36" height="76" rx="14" transform="rotate(-150)" />
+          </g>
+          <circle r="148" fill="#071226" stroke="#2fffc1" stroke-opacity="0.55" stroke-width="6" />
+          <circle r="116" fill="#071226" stroke="#2fffc1" stroke-width="4" stroke-opacity="0.85" />
+          <circle r="74" fill="#071226" stroke="#2fffc1" stroke-width="8" />
+          <circle r="32" fill="#071226" stroke="#2fffc1" stroke-width="4" stroke-opacity="0.6" />
+          <text y="16" text-anchor="middle" font-size="66" fill="#2fffc1" font-family="'Share Tech Mono','Fira Mono',monospace" letter-spacing=".3em">111</text>
+          <circle r="12" fill="#2fffc1" />
+        </g>
+        <g stroke="#2fffc1" stroke-width="2" stroke-opacity="0.35" fill="none">
+          <path d="M60 56h76l24 24h256l24-24h140" />
+          <path d="M60 340h148l18-24h168l18 24h168" />
+          <path d="M92 112h84l20 20h248l20-20h104" stroke-dasharray="10 14" />
+        </g>
+      </svg>
+    </figure>
+  </div>
 </header>
 <main>
+  <section class="card card--feature">
+    <figure class="card-visual">
+      <svg viewBox="0 0 640 360" role="img" aria-labelledby="blog-armor-title blog-armor-desc">
+        <title id="blog-armor-title">エネルギーアーマーの記録</title>
+        <desc id="blog-armor-desc">サイバーパンク世界の防護スーツをモチーフにしたヘッドライン用イラスト。</desc>
+        <defs>
+          <linearGradient id="blog-bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#0b1428" />
+            <stop offset="100%" stop-color="#1d0f2f" />
+          </linearGradient>
+          <linearGradient id="blog-metal" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#1f3659" />
+            <stop offset="100%" stop-color="#091224" />
+          </linearGradient>
+          <radialGradient id="blog-glow" cx="50%" cy="40%" r="60%">
+            <stop offset="0%" stop-color="#2fffc1" stop-opacity="0.95" />
+            <stop offset="100%" stop-color="#142542" stop-opacity="0.2" />
+          </radialGradient>
+        </defs>
+        <rect width="640" height="360" fill="url(#blog-bg)" />
+        <circle cx="320" cy="170" r="240" fill="url(#blog-glow)" opacity="0.3" />
+        <g transform="translate(320 170)">
+          <path d="M-210 94Q-228 22 -150 -88H150Q228 22 210 94Z" fill="url(#blog-metal)" stroke="#2fffc1" stroke-opacity="0.25" stroke-width="4" />
+          <path d="M-128 -80Q-116 -150 0 -170Q116 -150 128 -80Z" fill="#111b32" stroke="#2fffc1" stroke-opacity="0.3" stroke-width="4" />
+          <rect x="-130" y="-90" width="260" height="210" rx="72" fill="#0a162b" stroke="#2fffc1" stroke-opacity="0.35" stroke-width="6" />
+          <path d="M-170 76Q-150 8 -86 -32H86Q150 8 170 76Z" fill="#0d1a31" stroke="#2fffc1" stroke-opacity="0.3" stroke-width="3" />
+          <path d="M-82 26h164l40 92H-42Z" fill="#13223d" opacity="0.9" />
+          <rect x="-46" y="28" width="92" height="80" rx="18" fill="#06101f" stroke="#2fffc1" stroke-opacity="0.4" stroke-width="3" />
+          <rect x="-110" y="-20" width="220" height="70" rx="32" fill="#13233f" stroke="#2fffc1" stroke-opacity="0.3" stroke-width="3" />
+          <circle cx="-60" cy="-36" r="26" fill="#09162a" stroke="#2fffc1" stroke-width="4" />
+          <circle cx="60" cy="-36" r="26" fill="#09162a" stroke="#2fffc1" stroke-width="4" />
+          <circle cx="-60" cy="-36" r="12" fill="#2fffc1" opacity="0.8" />
+          <circle cx="60" cy="-36" r="12" fill="#2fffc1" opacity="0.8" />
+          <rect x="-54" y="-2" width="108" height="20" rx="10" fill="#0c192d" stroke="#2fffc1" stroke-opacity="0.5" />
+          <path d="M-92 74H92" stroke="#2fffc1" stroke-width="3" stroke-opacity="0.4" />
+          <circle cx="-112" cy="-12" r="10" fill="#2fffc1" opacity="0.7" />
+          <circle cx="112" cy="-12" r="10" fill="#2fffc1" opacity="0.7" />
+          <path d="M-180 60h36l16 26h-44z" fill="#2fffc133" />
+          <path d="M180 60h-36l-16 26h44z" fill="#2fffc133" />
+        </g>
+      </svg>
+    </figure>
+    <div class="card-text">
+      <h2>📰 SHOUN BLOG</h2>
+      <p>最新の活動報告や開発ストーリー、テクノロジーへの洞察を発信しています。近未来都市のネオンを感じるビジュアルとともに、制作裏話やカルチャーコラムをお届けします。</p>
+      <p><a class="btn" href="https://blog.shoun-llc.jp/">ブログを読む</a></p>
+    </div>
+  </section>
+
+  <section class="card card--feature card--alt">
+    <figure class="card-visual">
+      <svg viewBox="0 0 640 360" role="img" aria-labelledby="game-terminal-title game-terminal-desc">
+        <title id="game-terminal-title">レトロ端末インターフェース</title>
+        <desc id="game-terminal-desc">レトロフューチャーな探索端末をイメージしたグリッドとログのイラスト。</desc>
+        <defs>
+          <linearGradient id="game-bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#07121f" />
+            <stop offset="100%" stop-color="#101f34" />
+          </linearGradient>
+          <linearGradient id="game-screen" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#0b1f17" />
+            <stop offset="100%" stop-color="#06120c" />
+          </linearGradient>
+          <radialGradient id="game-glow" cx="50%" cy="50%" r="60%">
+            <stop offset="0%" stop-color="#56ff9d" stop-opacity="0.35" />
+            <stop offset="100%" stop-color="#0b1f17" stop-opacity="0" />
+          </radialGradient>
+        </defs>
+        <rect width="640" height="360" fill="url(#game-bg)" />
+        <rect x="66" y="46" width="508" height="268" rx="34" fill="#030a0d" stroke="#56ff9d" stroke-opacity="0.45" stroke-width="6" />
+        <rect x="104" y="78" width="432" height="204" rx="20" fill="url(#game-screen)" stroke="#56ff9d" stroke-opacity="0.65" stroke-width="3" />
+        <rect x="104" y="78" width="432" height="204" rx="20" fill="url(#game-glow)" />
+        <g stroke="#56ff9d" stroke-opacity="0.35" stroke-width="1.5">
+          <line x1="140" y1="106" x2="500" y2="106" />
+          <line x1="140" y1="142" x2="500" y2="142" />
+          <line x1="140" y1="178" x2="500" y2="178" />
+          <line x1="140" y1="214" x2="500" y2="214" />
+          <line x1="140" y1="250" x2="500" y2="250" />
+          <line x1="180" y1="106" x2="180" y2="278" />
+          <line x1="240" y1="106" x2="240" y2="278" />
+          <line x1="300" y1="106" x2="300" y2="278" />
+          <line x1="360" y1="106" x2="360" y2="278" />
+          <line x1="420" y1="106" x2="420" y2="278" />
+          <line x1="480" y1="106" x2="480" y2="278" />
+        </g>
+        <polyline points="140,222 180,214 216,196 248,210 280,186 320,208 352,170 388,182 420,154 452,170 488,146" fill="none" stroke="#56ff9d" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M188 256h112l18 18h-112z" fill="#56ff9d11" stroke="#56ff9d" stroke-opacity="0.45" stroke-width="2" />
+        <circle cx="260" cy="214" r="12" fill="#56ff9d" opacity="0.3" />
+        <circle cx="328" cy="190" r="18" fill="#56ff9d" opacity="0.18" />
+        <circle cx="360" cy="132" r="8" fill="#56ff9d" opacity="0.5" />
+        <text x="120" y="66" fill="#56ff9d" font-size="22" font-family="'Share Tech Mono','Fira Mono',monospace">RETRO-OS: SIGNAL LINKED</text>
+        <text x="120" y="300" fill="#56ff9d" font-size="16" font-family="'Share Tech Mono','Fira Mono',monospace">SHOUN GAMES // NEON ARCADE</text>
+        <g stroke="#56ff9d" stroke-width="4" stroke-opacity="0.5" fill="none">
+          <path d="M540 96h20v24h-20" />
+          <path d="M540 132h20v24h-20" />
+          <path d="M540 168h20v24h-20" />
+          <path d="M540 204h20v24h-20" />
+          <path d="M540 240h20v24h-20" />
+        </g>
+      </svg>
+    </figure>
+    <div class="card-text">
+      <h2>🎮 Tetris</h2>
+      <p>シンプル&amp;軽快なブラウザ版テトリス。レトロ端末のモニターを思わせるHUDで、ネオンが瞬く都市を旅するようにブロックを積み上げましょう。</p>
+      <!-- ポータル経由を判定できるよう from=portal を付与 -->
+      <p><a class="btn" href="https://tetris.shoun-llc.jp/?from=portal">今すぐプレイ</a></p>
+    </div>
+  </section>
+
   <section class="card">
-    <h2>🎮 Tetris</h2>
-    <p>シンプル&軽快なブラウザ版テトリス。キーボード操作に最適化しています。</p>
-    <!-- ポータル経由を判定できるよう from=portal を付与 -->
-    <p><a class="btn" href="https://tetris.shoun-llc.jp/?from=portal">今すぐプレイ</a></p>
+    <h2>📸 CYBER NEON ART GALLERY</h2>
+    <p>ネオンサインが瞬く街角から、輝く朝焼けの荒野まで、サイバーパンクな旅路を描いた5枚のアートワークを散りばめました。</p>
+    <div class="media-grid">
+      <figure>
+        <svg viewBox="0 0 520 320" role="img" aria-labelledby="gallery-nuka-title gallery-nuka-desc">
+          <title id="gallery-nuka-title">ネオンサインとバーラウンジ</title>
+          <desc id="gallery-nuka-desc">近未来都市のダウンタウンを思わせる、ネオンサインが輝く路地のイラスト。</desc>
+          <defs>
+            <linearGradient id="gallery-nuka-bg" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#150a2c" />
+              <stop offset="100%" stop-color="#04060f" />
+            </linearGradient>
+            <linearGradient id="gallery-nuka-neon" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stop-color="#ff477e" />
+              <stop offset="100%" stop-color="#ffd359" />
+            </linearGradient>
+          </defs>
+          <rect width="520" height="320" fill="url(#gallery-nuka-bg)" />
+          <path d="M0 266C76 238 150 240 222 260s144 16 212-10 86-34 86-34V320H0Z" fill="#060d1c" />
+          <g fill="#0b1527">
+            <rect x="40" y="120" width="96" height="176" rx="12" />
+            <rect x="150" y="90" width="86" height="206" rx="12" />
+            <rect x="248" y="110" width="92" height="186" rx="12" />
+            <rect x="360" y="134" width="68" height="162" rx="12" />
+          </g>
+          <g fill="#192a4a">
+            <rect x="60" y="140" width="16" height="30" rx="4" />
+            <rect x="80" y="140" width="16" height="30" rx="4" />
+            <rect x="100" y="140" width="16" height="30" rx="4" />
+            <rect x="60" y="184" width="16" height="30" rx="4" />
+            <rect x="80" y="184" width="16" height="30" rx="4" />
+            <rect x="100" y="184" width="16" height="30" rx="4" />
+            <rect x="170" y="112" width="20" height="32" rx="6" />
+            <rect x="198" y="112" width="20" height="32" rx="6" />
+            <rect x="170" y="164" width="20" height="32" rx="6" />
+            <rect x="198" y="164" width="20" height="32" rx="6" />
+            <rect x="268" y="132" width="24" height="36" rx="6" />
+            <rect x="300" y="132" width="24" height="36" rx="6" />
+            <rect x="268" y="184" width="24" height="36" rx="6" />
+            <rect x="300" y="184" width="24" height="36" rx="6" />
+          </g>
+          <g>
+            <rect x="336" y="72" width="156" height="70" rx="18" fill="#ff477e22" stroke="url(#gallery-nuka-neon)" stroke-width="4" />
+            <text x="414" y="112" text-anchor="middle" fill="#ffd359" font-size="32" font-family="'Share Tech Mono','Fira Mono',monospace">NEON</text>
+            <text x="414" y="132" text-anchor="middle" fill="#ff94d2" font-size="16" font-family="'Share Tech Mono','Fira Mono',monospace">LOUNGE</text>
+          </g>
+          <g stroke="#ff94d2" stroke-width="3" stroke-opacity="0.6" fill="none">
+            <path d="M120 86h44l18 18h120l18-18h42" />
+            <path d="M60 214h104l18 18h132l18-18h110" />
+          </g>
+          <circle cx="368" cy="94" r="8" fill="#ffd359" />
+          <circle cx="460" cy="94" r="8" fill="#ff477e" />
+          <path d="M180 248c18-16 48-24 82-18s62 26 98 22 72-26 104-42" stroke="#ff477e44" stroke-width="6" fill="none" stroke-linecap="round" />
+        </svg>
+        <figcaption>近未来都市の路地を飾るバーラウンジのネオンサイン。住民の息遣いとサイバーパンク調の光が交差します。</figcaption>
+      </figure>
+      <figure>
+        <svg viewBox="0 0 520 320" role="img" aria-labelledby="gallery-glow-title gallery-glow-desc">
+          <title id="gallery-glow-title">ルミナスウェイの黎明</title>
+          <desc id="gallery-glow-desc">放射線が揺らめくような光彩が広がる夜明けの荒野を描いたイラスト。</desc>
+          <defs>
+            <linearGradient id="gallery-glow-sky" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#0a1526" />
+              <stop offset="60%" stop-color="#132b3b" />
+              <stop offset="100%" stop-color="#1b3f30" />
+            </linearGradient>
+            <radialGradient id="gallery-glow-sun" cx="50%" cy="40%" r="40%">
+              <stop offset="0%" stop-color="#fffd8a" />
+              <stop offset="60%" stop-color="#ffd75a" stop-opacity="0.65" />
+              <stop offset="100%" stop-color="#00ffb0" stop-opacity="0.15" />
+            </radialGradient>
+            <linearGradient id="gallery-glow-ground" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stop-color="#091b1c" />
+              <stop offset="100%" stop-color="#1b342d" />
+            </linearGradient>
+          </defs>
+          <rect width="520" height="320" fill="url(#gallery-glow-sky)" />
+          <circle cx="260" cy="136" r="132" fill="url(#gallery-glow-sun)" opacity="0.7" />
+          <path d="M0 220C40 198 108 180 176 192s128 40 188 38 102-36 156-50v140H0Z" fill="url(#gallery-glow-ground)" />
+          <path d="M60 214c48-32 92-42 160-26s144 64 212 42" stroke="#58ffb422" stroke-width="10" fill="none" stroke-linecap="round" />
+          <path d="M118 236l32-52 44 36 42-60 46 56 36-46 36 50 30-34 36 40" stroke="#9efff544" stroke-width="6" fill="none" stroke-linejoin="round" />
+          <path d="M74 262c18-20 42-30 74-24s58 28 102 26 98-32 152-28 84 28 84 28" stroke="#fffb8c33" stroke-width="4" fill="none" stroke-dasharray="8 12" />
+          <circle cx="112" cy="220" r="6" fill="#fffd8a" />
+          <circle cx="222" cy="198" r="8" fill="#9efff5" />
+          <circle cx="332" cy="210" r="6" fill="#fffd8a" />
+          <circle cx="412" cy="188" r="10" fill="#9efff5" />
+        </svg>
+        <figcaption>ルミナスウェイの朝焼け。光が渦巻く荒野の奥に、冒険者が目指すシルエットが浮かび上がります。</figcaption>
+      </figure>
+    </div>
   </section>
 
   <section class="card">

--- a/privacy.html
+++ b/privacy.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8">
-  <title>プライバシーポリシー | SHOUN GAMES</title>
+  <title>プライバシーポリシー | SHOUN PORTAL</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0}
@@ -18,7 +18,7 @@
 </header>
 <main>
   <section>
-    <p>このポリシーは <strong>shoun-llc.jp</strong> およびそのサブドメイン（例：tetris.shoun-llc.jp）に適用されます。</p>
+    <p>このポリシーは <strong>www.shoun-llc.jp</strong> および <strong>shoun-llc.jp</strong> とそのサブドメイン（例：tetris.shoun-llc.jp）に適用されます。</p>
   </section>
   <section>
     <h2>個人情報の収集と利用</h2>

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,8 @@
   "redirects": [
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "www.shoun-llc.jp" }],
-      "destination": "https://shoun-llc.jp/:path*",
+      "has": [{ "type": "host", "value": "shoun-llc.jp" }],
+      "destination": "https://www.shoun-llc.jp/:path*",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Summary
- retitle the portal and metadata to cover both the blog and games
- add a hero section with neon styling to introduce the blog and game destinations
- introduce a blog highlight card, retro terminal Tetris card, and a two-piece neon art gallery to distribute five themed images across the page
- remove Fallout-specific references from copy and accessibility text while preserving the existing artwork
- point canonical metadata and redirects to https://www.shoun-llc.jp to keep privacy links from bouncing between domains

## Testing
- not run (static HTML page)

------
https://chatgpt.com/codex/tasks/task_e_68cfbcb913bc83208bbebc0ef7af8231